### PR TITLE
Modified gists.js to account for the correct Dropbox base URL

### DIFF
--- a/js/gist.js
+++ b/js/gist.js
@@ -15,7 +15,9 @@
 
 function Gist($, $content) {
 
-    var DROPBOX_BASE_URL = 'https://dl.dropboxusercontent.com/u/';
+    /*var DROPBOX_BASE_URL = 'https://dl.dropboxusercontent.com/u/';*/
+    var DROPBOX_BASE_URL = 'https://www.dropbox.com/s/';
+    
     var VALID_GIST = /^[0-9a-f]{5,32}\/?$/;
 
     return {'getGistAndRenderPage': getGistAndRenderPage, 'readSourceId': readSourceId};


### PR DESCRIPTION
I couldn't get links to AsciiDoc files in Dropbox to work. For example, this GraphGist failed https://www.dropbox.com/s/edrw7kbhetwyzza/gistcheck.adoc failed with the error message 

```
Error
Something went wrong fetching the GraphGist "https%3A%2F%2Fwww.dropbox.com%2Fs%2Fedrw7kbhetwyzza%2Fgistcheck.adoc":
```

This appears to be because the `DROPBOX_BASE_URL` in [gists.js](https://github.com/neo4j-contrib/graphgist/blob/master/js/gist.js) is `https://dl.dropboxusercontent.com/u/` but the URLs I'm getting from Dropbox these days are prefixed with `https://www.dropbox.com/s/`
