### PR TITLE
Fix panning and console.log errors

### DIFF
--- a/js/neod3-visualization.js
+++ b/js/neod3-visualization.js
@@ -95,7 +95,13 @@ function Neod3Renderer() {
         }
 
         function disableZoomHandlers() {
-            renderer.on(".zoom",null);
+            renderer.on("wheel.zoom",null);
+            renderer.on("mousewheel.zoom",null);
+            renderer.on("mousedown.zoom", null);
+            renderer.on("DOMMouseScroll.zoom", null);
+            renderer.on("touchstart.zoom",null);
+            renderer.on("touchmove.zoom",null);
+            renderer.on("touchend.zoom",null);
         }
 
         function altHandler() {

--- a/js/neod3-visualization.js
+++ b/js/neod3-visualization.js
@@ -84,21 +84,22 @@ function Neod3Renderer() {
             renderer.select(".relationships").attr("transform", "translate(" + d3.event.translate + ")scale(" + d3.event.scale + ")");
         }
 
-        function zoomStart() {
-            if (d3.event.sourceEvent.altKey) {
-                zoomBehavior.on("zoom", applyZoom);
-                renderer.on("mousedown.zoom", null)
+        function enableZoomHandlers() {
+            renderer.on("wheel.zoom",zoomHandlers.wheel);
+            renderer.on("mousedown.zoom",zoomHandlers.mousedown);
+        }
+
+        function disableZoomHandlers() {
+            renderer.on("wheel.zoom",null);
+            renderer.on("mousedown.zoom", null);
+        }
+
+        function altHandler() {
+            if (d3.event.altKey) {
+                enableZoomHandlers();
             }
             else {
-                zoomBehavior
-                    .on("mousedown.zoom", null)
-                    .on("mousewheel.zoom", null)
-                    .on("mousemove.zoom", null)
-                    .on("DOMMouseScroll.zoom", null)
-                    .on("dblclick.zoom", null)
-                    .on("touchstart.zoom", null)
-                    .on("touchmove.zoom", null)
-                    .on("touchend.zoom", null);
+               disableZoomHandlers();
             }
         }
 
@@ -121,10 +122,17 @@ function Neod3Renderer() {
             .style(styleSheet)
             .width($container.width()).height($container.height()).on('nodeClicked', dummyFunc).on('relationshipClicked', dummyFunc).on('nodeDblClicked', dummyFunc);
         var renderer = d3.select("#" + id).append("svg").data([graphModel]);
-        var zoomBehavior = d3.behavior.zoom().on("zoomstart", zoomStart).scaleExtent([0.2, 8])
+        var zoomHandlers = {};
+        var zoomBehavior = d3.behavior.zoom().on("zoom", applyZoom).scaleExtent([0.2, 8])
 
         renderer.call(graphView);
         renderer.call(zoomBehavior);
+
+        zoomHandlers.wheel = renderer.on("wheel.zoom");
+        zoomHandlers.mousedown = renderer.on("mousedown.zoom");
+        disableZoomHandlers();
+
+        d3.select('body').on("keydown", altHandler).on("keyup", altHandler);
 
         function refresh() {
             graphView.height($container.height());

--- a/js/neod3-visualization.js
+++ b/js/neod3-visualization.js
@@ -87,11 +87,13 @@ function Neod3Renderer() {
         function enableZoomHandlers() {
             renderer.on("wheel.zoom",zoomHandlers.wheel);
             renderer.on("mousedown.zoom",zoomHandlers.mousedown);
+            renderer.on("DOMMouseScroll.zoom",zoomHandlers.DOMMouseScroll);
         }
 
         function disableZoomHandlers() {
             renderer.on("wheel.zoom",null);
             renderer.on("mousedown.zoom", null);
+            renderer.on("DOMMouseScroll.zoom", null);
         }
 
         function altHandler() {
@@ -130,6 +132,7 @@ function Neod3Renderer() {
 
         zoomHandlers.wheel = renderer.on("wheel.zoom");
         zoomHandlers.mousedown = renderer.on("mousedown.zoom");
+        zoomHandlers.DOMMouseScroll = renderer.on("DOMMouseScroll.zoom");
         disableZoomHandlers();
 
         d3.select('body').on("keydown", altHandler).on("keyup", altHandler);

--- a/js/neod3-visualization.js
+++ b/js/neod3-visualization.js
@@ -89,13 +89,13 @@ function Neod3Renderer() {
             renderer.on("mousewheel.zoom",zoomHandlers.mousewheel);
             renderer.on("mousedown.zoom",zoomHandlers.mousedown);
             renderer.on("DOMMouseScroll.zoom",zoomHandlers.DOMMouseScroll);
+            renderer.on("touchstart.zoom",zoomHandlers.touchstart);
+            renderer.on("touchmove.zoom",zoomHandlers.touchmove);
+            renderer.on("touchend.zoom",zoomHandlers.touchend);
         }
 
         function disableZoomHandlers() {
-            renderer.on("wheel.zoom",null);
-            renderer.on("mousewheel.zoom",null);
-            renderer.on("mousedown.zoom", null);
-            renderer.on("DOMMouseScroll.zoom", null);
+            renderer.on(".zoom",null);
         }
 
         function altHandler() {
@@ -127,7 +127,7 @@ function Neod3Renderer() {
             .width($container.width()).height($container.height()).on('nodeClicked', dummyFunc).on('relationshipClicked', dummyFunc).on('nodeDblClicked', dummyFunc);
         var renderer = d3.select("#" + id).append("svg").data([graphModel]);
         var zoomHandlers = {};
-        var zoomBehavior = d3.behavior.zoom().on("zoom", applyZoom).scaleExtent([0.2, 8])
+        var zoomBehavior = d3.behavior.zoom().on("zoom", applyZoom).scaleExtent([0.2, 8]);
 
         renderer.call(graphView);
         renderer.call(zoomBehavior);
@@ -136,6 +136,9 @@ function Neod3Renderer() {
         zoomHandlers.mousewheel = renderer.on("mousewheel.zoom");
         zoomHandlers.mousedown = renderer.on("mousedown.zoom");
         zoomHandlers.DOMMouseScroll = renderer.on("DOMMouseScroll.zoom");
+        zoomHandlers.touchstart = renderer.on("touchstart.zoom");
+        zoomHandlers.touchmove = renderer.on("touchmove.zoom")
+        zoomHandlers.touchend = renderer.on("touchend.zoom");
         disableZoomHandlers();
 
         d3.select('body').on("keydown", altHandler).on("keyup", altHandler);

--- a/js/neod3-visualization.js
+++ b/js/neod3-visualization.js
@@ -86,12 +86,14 @@ function Neod3Renderer() {
 
         function enableZoomHandlers() {
             renderer.on("wheel.zoom",zoomHandlers.wheel);
+            renderer.on("mousewheel.zoom",zoomHandlers.mousewheel);
             renderer.on("mousedown.zoom",zoomHandlers.mousedown);
             renderer.on("DOMMouseScroll.zoom",zoomHandlers.DOMMouseScroll);
         }
 
         function disableZoomHandlers() {
             renderer.on("wheel.zoom",null);
+            renderer.on("mousewheel.zoom",null);
             renderer.on("mousedown.zoom", null);
             renderer.on("DOMMouseScroll.zoom", null);
         }
@@ -131,6 +133,7 @@ function Neod3Renderer() {
         renderer.call(zoomBehavior);
 
         zoomHandlers.wheel = renderer.on("wheel.zoom");
+        zoomHandlers.mousewheel = renderer.on("mousewheel.zoom");
         zoomHandlers.mousedown = renderer.on("mousedown.zoom");
         zoomHandlers.DOMMouseScroll = renderer.on("DOMMouseScroll.zoom");
         disableZoomHandlers();


### PR DESCRIPTION
This should fix the panning issues and also the ".on" errors that were coming up before.

I'm not sure what to do with things like double click zooming and touches. I've enabled them for now but check out if this behaviour is what you want.
