### PR TITLE
Change class of content's parent element from row to containter

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     </div>
 </div>
 
-<div class="row">
+<div class="container">
     <div id="content" class="span10 offset1">
         <img alt="loading" src="images/loading.gif" class="loading">
     </div>


### PR DESCRIPTION
Hi,
It seems there is a little mistake, parent element of content has a wrong class:

here we have the 'row' class:
![screenshot from 2014-08-04 12 49 36](https://cloud.githubusercontent.com/assets/1634282/3794920/67a3f1c0-1bb4-11e4-9134-d69f70cce1ff.png)

so I propose to use the 'container' class instead of it:
![screenshot from 2014-08-04 12 49 51](https://cloud.githubusercontent.com/assets/1634282/3794921/67a4a106-1bb4-11e4-99f7-db1929149e8f.png)

Thanks in advance!
